### PR TITLE
Support for broadcasting data to xDrip+

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -67,6 +67,9 @@
         <service
             android:name=".upload.nightscout.NightscoutUploadIntentService"
             android:icon="@drawable/ic_launcher" />
+        <service
+            android:name=".xdrip_plus.XDripPlusUploadIntentService"
+            android:icon="@drawable/ic_launcher" />
 
         <service
             android:name=".medtronic.service.MedtronicCnlIntentService"
@@ -76,6 +79,7 @@
 
         <receiver android:name=".medtronic.service.MedtronicCnlAlarmReceiver" />
         <receiver android:name=".upload.nightscout.NightscoutUploadReceiver" />
+        <receiver android:name=".xdrip_plus.XDripPlusUploadReceiver" />
 
     </application>
 

--- a/app/src/main/java/info/nightscout/android/medtronic/service/MedtronicCnlIntentService.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/service/MedtronicCnlIntentService.java
@@ -5,9 +5,12 @@ import android.app.IntentService;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.hardware.usb.UsbDevice;
 import android.hardware.usb.UsbManager;
+import android.os.Build;
+import android.preference.PreferenceManager;
 import android.support.v4.app.NotificationManagerCompat;
 import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
@@ -17,6 +20,7 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.concurrent.TimeoutException;
 
+import info.nightscout.android.R;
 import info.nightscout.android.USB.UsbHidDriver;
 import info.nightscout.android.medtronic.MainActivity;
 import info.nightscout.android.medtronic.MedtronicCNLReader;
@@ -28,6 +32,7 @@ import info.nightscout.android.model.medtronicNg.ContourNextLinkInfo;
 import info.nightscout.android.model.medtronicNg.PumpInfo;
 import info.nightscout.android.model.medtronicNg.PumpStatusEvent;
 import info.nightscout.android.upload.nightscout.NightscoutUploadReceiver;
+import info.nightscout.android.xdrip_plus.XDripPlusUploadReceiver;
 import io.realm.Realm;
 import io.realm.RealmResults;
 
@@ -274,8 +279,31 @@ public class MedtronicCnlIntentService extends IntentService {
             }
 
             // TODO - set status if offline or Nightscout not reachable
+            sendToXDrip();
             uploadToNightscout();
             MedtronicCnlAlarmReceiver.completeWakefulIntent(intent);
+        }
+    }
+
+    // reliable wake alarm manager wake up for all android versions
+    public static void wakeUpIntent(Context context, long wakeTime, PendingIntent pendingIntent) {
+        final AlarmManager alarm = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            alarm.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, wakeTime, pendingIntent);
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            alarm.setExact(AlarmManager.RTC_WAKEUP, wakeTime, pendingIntent);
+        } else
+            alarm.set(AlarmManager.RTC_WAKEUP, wakeTime, pendingIntent);
+    }
+
+    private void sendToXDrip() {
+        final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
+        if (prefs.getBoolean(getString(R.string.preference_enable_xdrip_plus), false)) {
+            final Intent receiverIntent = new Intent(this, XDripPlusUploadReceiver.class);
+            final long timestamp = System.currentTimeMillis() + 500L;
+            final PendingIntent pendingIntent = PendingIntent.getBroadcast(this, (int) timestamp, receiverIntent, PendingIntent.FLAG_ONE_SHOT);
+            Log.d(TAG,"Scheduling xDrip+ send");
+            wakeUpIntent(getApplicationContext(), timestamp, pendingIntent);
         }
     }
 

--- a/app/src/main/java/info/nightscout/android/xdrip_plus/XDripPlusUploadIntentService.java
+++ b/app/src/main/java/info/nightscout/android/xdrip_plus/XDripPlusUploadIntentService.java
@@ -1,0 +1,171 @@
+package info.nightscout.android.xdrip_plus;
+
+import android.app.IntentService;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.ResolveInfo;
+import android.os.Bundle;
+import android.support.v4.content.LocalBroadcastManager;
+import android.util.Log;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.math.BigDecimal;
+import java.text.SimpleDateFormat;
+import java.util.List;
+import java.util.Locale;
+
+import info.nightscout.android.medtronic.MainActivity;
+import info.nightscout.android.model.medtronicNg.PumpStatusEvent;
+import info.nightscout.android.upload.nightscout.serializer.EntriesSerializer;
+import io.realm.Realm;
+import io.realm.RealmResults;
+import io.realm.Sort;
+
+/**
+ * Created by jamorham on 17/11/2016.
+ */
+
+
+public class XDripPlusUploadIntentService extends IntentService {
+
+    private static final String TAG = XDripPlusUploadIntentService.class.getSimpleName();
+    private static final SimpleDateFormat ISO8601_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.getDefault());
+    Context mContext;
+    private Realm mRealm;
+
+    public XDripPlusUploadIntentService() {
+        super(XDripPlusUploadIntentService.class.getName());
+    }
+
+    // status unused
+    protected void sendStatus(String message) {
+        Intent localIntent =
+                new Intent(info.nightscout.android.xdrip_plus.XDripPlusUploadIntentService.Constants.ACTION_STATUS_MESSAGE)
+                        .putExtra(info.nightscout.android.xdrip_plus.XDripPlusUploadIntentService.Constants.EXTENDED_DATA, message);
+        LocalBroadcastManager.getInstance(this).sendBroadcast(localIntent);
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        Log.i(TAG, "onCreate called");
+        mContext = this.getBaseContext();
+    }
+
+    @Override
+    protected void onHandleIntent(Intent intent) {
+        Log.d(TAG, "onHandleIntent called");
+        mRealm = Realm.getDefaultInstance();
+
+        RealmResults<PumpStatusEvent> all_records = mRealm
+                .where(PumpStatusEvent.class)
+                .notEqualTo("sgv", 0)
+                .findAllSorted("eventDate", Sort.DESCENDING);
+
+        // get the most recent record and send that
+        if (all_records.size() > 0) {
+            List<PumpStatusEvent> records = all_records.subList(0, 1);
+            doXDripUpload(records);
+        }
+        XDripPlusUploadReceiver.completeWakefulIntent(intent);
+    }
+
+    private void doXDripUpload(List<PumpStatusEvent> records) {
+        try {
+
+            final JSONArray devicestatusBody = new JSONArray();
+            final JSONArray entriesBody = new JSONArray();
+
+            for (PumpStatusEvent record : records) {
+                addDeviceStatus(devicestatusBody, record);
+                addSgvEntry(entriesBody, record);
+                addMbgEntry(entriesBody, record);
+            }
+
+            if (entriesBody.length() > 0) sendBundle(mContext, "add", "entries", entriesBody);
+            if (devicestatusBody.length() > 0)
+                sendBundle(mContext, "add", "devicestatus", devicestatusBody);
+
+        } catch (Exception e) {
+            Log.e(TAG, "Unable to send bundle: " + e);
+        }
+    }
+
+    private void sendBundle(Context context, String action, String collection, JSONArray json) {
+        final Bundle bundle = new Bundle();
+        bundle.putString("action", action);
+        bundle.putString("collection", collection);
+        bundle.putString("data", json.toString());
+        final Intent intent = new Intent(Constants.XDRIP_PLUS_NS_EMULATOR);
+        intent.putExtras(bundle).addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
+        context.sendBroadcast(intent);
+        List<ResolveInfo> receivers = context.getPackageManager().queryBroadcastReceivers(intent, 0);
+        if (receivers.size() < 1) {
+            Log.e(TAG, "No receivers");
+        } else Log.e(TAG, receivers.size() + " receivers");
+    }
+
+
+    private void addDeviceStatus(JSONArray devicestatusArray, PumpStatusEvent record) throws Exception {
+        JSONObject json = new JSONObject();
+        json.put("uploaderBattery", MainActivity.batLevel);
+        json.put("device", record.getDeviceName());
+        json.put("created_at", ISO8601_DATE_FORMAT.format(record.getPumpDate()));
+
+        JSONObject pumpInfo = new JSONObject();
+        pumpInfo.put("clock", ISO8601_DATE_FORMAT.format(record.getPumpDate()));
+        pumpInfo.put("reservoir", new BigDecimal(record.getReservoirAmount()).setScale(3, BigDecimal.ROUND_HALF_UP));
+
+        JSONObject iob = new JSONObject();
+        iob.put("timestamp", record.getPumpDate());
+        iob.put("bolusiob", record.getActiveInsulin());
+
+        JSONObject battery = new JSONObject();
+        battery.put("percent", record.getBatteryPercentage());
+
+        pumpInfo.put("iob", iob);
+        pumpInfo.put("battery", battery);
+        json.put("pump", pumpInfo);
+        //String jsonString = json.toString();
+
+        devicestatusArray.put(json);
+    }
+
+    private void addSgvEntry(JSONArray entriesArray, PumpStatusEvent pumpRecord) throws Exception {
+        JSONObject json = new JSONObject();
+        // TODO replace with Retrofit/EntriesSerializer
+        json.put("sgv", pumpRecord.getSgv());
+        json.put("direction", EntriesSerializer.getDirectionString(pumpRecord.getCgmTrend()));
+        json.put("device", pumpRecord.getDeviceName());
+        json.put("type", "sgv");
+        json.put("date", pumpRecord.getEventDate().getTime());
+        json.put("dateString", pumpRecord.getEventDate());
+
+        entriesArray.put(json);
+    }
+
+    private void addMbgEntry(JSONArray entriesArray, PumpStatusEvent pumpRecord) throws Exception {
+        if (pumpRecord.hasRecentBolusWizard()) {
+            JSONObject json = new JSONObject();
+
+            // TODO replace with Retrofit/EntriesSerializer
+            json.put("type", "mbg");
+            json.put("mbg", pumpRecord.getBolusWizardBGL());
+            json.put("device", pumpRecord.getDeviceName());
+            json.put("date", pumpRecord.getEventDate().getTime());
+            json.put("dateString", pumpRecord.getEventDate());
+
+            entriesArray.put(json);
+        }
+    }
+
+
+    public final class Constants {
+        public static final String ACTION_STATUS_MESSAGE = "info.nightscout.android.xdrip_plus.STATUS_MESSAGE";
+        public static final String EXTENDED_DATA = "info.nightscout.android.xdrip_plus.DATA";
+        private static final String XDRIP_PLUS_NS_EMULATOR = "com.eveningoutpost.dexdrip.NS_EMULATOR";
+    }
+}

--- a/app/src/main/java/info/nightscout/android/xdrip_plus/XDripPlusUploadReceiver.java
+++ b/app/src/main/java/info/nightscout/android/xdrip_plus/XDripPlusUploadReceiver.java
@@ -1,0 +1,22 @@
+package info.nightscout.android.xdrip_plus;
+
+import android.content.Context;
+import android.content.Intent;
+import android.support.v4.content.WakefulBroadcastReceiver;
+import android.util.Log;
+
+
+/**
+ * Created by jamorham on 17/11/2016.
+ */
+public class XDripPlusUploadReceiver extends WakefulBroadcastReceiver {
+    private static final String TAG = XDripPlusUploadReceiver.class.getSimpleName();
+
+    @Override
+    public void onReceive(final Context context, Intent intent) {
+        // Start the IntentService
+        Log.d(TAG, "Received broadcast message");
+        Intent service = new Intent(context, XDripPlusUploadIntentService.class);
+        startWakefulService(context, service);
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,7 @@
     <string name="button_text_start_uploading_data">Start Uploading CGM Data</string>
     <string name="preference_eula_accepted">IUNDERSTAND</string>
     <string name="preference_enable_rest_upload">EnableRESTUpload</string>
+    <string name="preference_enable_xdrip_plus">EnablexDripPlusUpload</string>
     <string name="error_msg_api_secret_length">API Secret must be 12 characters or longer.</string>
     <string name="text_unit_mmolxl">mmol/L</string>
     <string name="text_unit_mgxdl">mg/dL</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -39,6 +39,10 @@
             android:dialogTitle="Enter your Nightscout API secret"
             android:key="@string/preference_api_secret"
             android:title="API Secret"/>
+        <CheckBoxPreference
+            android:key="@string/preference_enable_xdrip_plus"
+            android:summary="Enable local broadcast of data to xDrip+"
+            android:title="Send to xDrip+"/>
     </PreferenceCategory>
     <PreferenceCategory android:title="Disclaimer">
         <SwitchPreference


### PR DESCRIPTION
This PR adds support for broadcasting the 640g data to xDrip+ running on the same handset/device, allowing it to be used as a data source for that app. 

I've been asked to find a way to get this to work by xDrip+ users who wish to use your excellent app as a data source, but without using a network connection to a Nightscout web instance. 

The patch creates a new preference item and intent service which should be triggered on new data and when the preference item is set.  It then extracts the most recent record only and broadcasts this locally.

xDrip+ versions from 18th Nov onward are able to process this data when set in `Follower` mode.  

Where possible, the existing application structure has been mirrored when creating this patch to hopefully make it as easy as possible to understand and integrate. 

You may notice the `wakeUpIntent` method which is included.  I believe this is a more robust way to schedule alarms on all android versions, taking in to consideration the limitations introduced in android 6 with doze mode.  

I do not have a 640G to test this with and so for testing I created a test harness to simulate how I think the data would be presented. I believe this has a strong chance of success but there is no substitute for real world testing. 

Please let me know your any comments or questions.

Thanks.

Jon