### PR TITLE
Develop invincible

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -144,7 +144,7 @@ release {
 
 dependencies {
     compile files('libs/slf4j-api-1.7.2.jar')
-    compile('com.crashlytics.sdk.android:crashlytics:2.6.5@aar') {
+    compile('com.crashlytics.sdk.android:crashlytics:2.6.6@aar') {
         transitive = true;
     }
     compile('com.mikepenz:materialdrawer:5.2.9@aar') {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,11 +31,13 @@
 
 
         <!-- I have set screenOrientation to "portrait" to avoid the restart of AsyncTasks when you rotate the phone -->
+        <!-- configChanges="uiMode" added to avoid restart of AsyncTasks when phone is plugged into charger/dock (for phones that can do usb otg & charging simultaneously -->
         <activity
             android:name=".medtronic.MainActivity"
             android:icon="@drawable/ic_launcher"
             android:label="@string/app_name"
             android:launchMode="singleTask"
+            android:configChanges="uiMode"
             android:screenOrientation="portrait">
 
             <intent-filter android:icon="@drawable/ic_launcher">

--- a/app/src/main/java/info/nightscout/android/medtronic/MainActivity.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/MainActivity.java
@@ -94,23 +94,13 @@ public class MainActivity extends AppCompatActivity implements OnSharedPreferenc
     private int chartZoom = 3;
     private boolean hasZoomedChart = false;
 
-    public static NumberFormat sgvFormatter;
-    public static boolean mmolxl;
-    private boolean mmolxlDecimals;
+    private NumberFormat sgvFormatter;
+    private static boolean mmolxl;
+    private static boolean mmolxlDecimals;
 
-    public static byte radioChannelInuse = 0;
-    public static long timeLastEHSM = 0;
     public static long timeLastGoodSGV = 0;
     public static short pumpBattery = 0;
     public static int countUnavailableSGV = 0;
-
-    // temporary debug stats for CNL connections
-    public static int dbgCNL_enterControlMode = 0;
-    public static int dbgCNL_enterPassthroughMode = 0;
-    public static int dbgCNL_openConnection = 0;
-    public static int dbgCNL_beginEHSMSession = 0;
-    public static int dbgCNL_clearMessage = 0;
-    public static int dbgCNL_not0x81 = 0;
 
     boolean mEnableCgmService = true;
     SharedPreferences prefs = null;
@@ -124,6 +114,18 @@ public class MainActivity extends AppCompatActivity implements OnSharedPreferenc
     private StatusMessageReceiver statusMessageReceiver = new StatusMessageReceiver();
     private MedtronicCnlAlarmReceiver medtronicCnlAlarmReceiver = new MedtronicCnlAlarmReceiver();
 
+    public static String strFormatSGV(float sgvValue) {
+        if (mmolxl) {
+            NumberFormat sgvFormatter;
+            if (mmolxlDecimals)
+                sgvFormatter = new DecimalFormat("0.00");
+            else
+                sgvFormatter = new DecimalFormat("0.0");
+            return sgvFormatter.format(sgvValue / MMOLXLFACTOR);
+        } else {
+            return String.valueOf(sgvValue);
+        }
+    }
 
     public static long getNextPoll(PumpStatusEvent pumpStatusData) {
         long nextPoll = pumpStatusData.getEventDate().getTime() + pumpStatusData.getPumpTimeOffset()
@@ -333,7 +335,6 @@ public class MainActivity extends AppCompatActivity implements OnSharedPreferenc
         mChart.getGridLabelRenderer().setHumanRounding(false);
 
         mChart.getGridLabelRenderer().setLabelFormatter(new DefaultLabelFormatter() {
-//            DateFormat mFormat = DateFormat.getTimeInstance(DateFormat.SHORT);
             DateFormat mFormat = new SimpleDateFormat("HH:mm");  // 24 hour format forced to fix label overlap
 
             @Override
@@ -341,11 +342,7 @@ public class MainActivity extends AppCompatActivity implements OnSharedPreferenc
                 if (isValueX) {
                     return mFormat.format(new Date((long) value));
                 } else {
-//                    if (mmolxl) {
-//                        return sgvFormatter.format(value / MMOLXLFACTOR);
-//                    } else {
                         return sgvFormatter.format(value);
-//                    }
                 }
             }}
         );
@@ -859,11 +856,7 @@ public class MainActivity extends AppCompatActivity implements OnSharedPreferenc
                         double sgv = dataPoint.getY();
 
                         StringBuilder sb = new StringBuilder(mFormat.format(new Date((long) dataPoint.getX())) + ": ");
-//                        if (mmolxl) {
-//                            sb.append(sgvFormatter.format(sgv / MMOLXLFACTOR));
-//                        } else {
-                            sb.append(sgvFormatter.format(sgv));
-//                        }
+                        sb.append(sgvFormatter.format(sgv));
                         Toast.makeText(getBaseContext(), sb.toString(), Toast.LENGTH_SHORT).show();
                     }
                 });

--- a/app/src/main/java/info/nightscout/android/medtronic/MainActivity.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/MainActivity.java
@@ -98,6 +98,12 @@ public class MainActivity extends AppCompatActivity implements OnSharedPreferenc
     public static boolean mmolxl;
     private boolean mmolxlDecimals;
 
+    public static byte radioChannelInuse = 0;
+    public static long timeLastEHSM = 0;
+    public static long timeLastGoodSGV = 0;
+    public static short pumpBattery = 0;
+    public static int countUnavailableSGV = 0;
+
     boolean mEnableCgmService = true;
     SharedPreferences prefs = null;
     private PumpInfo mActivePump;
@@ -595,7 +601,8 @@ public class MainActivity extends AppCompatActivity implements OnSharedPreferenc
 
                         lastQueryTS = pump.getLastQueryTS();
 
-                        startCgmService(MainActivity.getNextPoll(pumpStatusData));
+// >>>>> note: prototype smart poll handling added to cnl intent
+//                        startCgmService(MainActivity.getNextPoll(pumpStatusData));
 
                         // Delete invalid or old records from Realm
                         // TODO - show an error message if the valid records haven't been uploaded

--- a/app/src/main/java/info/nightscout/android/medtronic/MainActivity.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/MainActivity.java
@@ -663,7 +663,7 @@ public class MainActivity extends AppCompatActivity implements OnSharedPreferenc
             }
         }
 
-        private Queue<StatusMessage> messages = new ArrayBlockingQueue<>(10);
+        private Queue<StatusMessage> messages = new ArrayBlockingQueue<>(400);
 
         @Override
         public void onReceive(Context context, Intent intent) {
@@ -671,7 +671,7 @@ public class MainActivity extends AppCompatActivity implements OnSharedPreferenc
             Log.i(TAG, "Message Receiver: " + message);
 
             synchronized (messages) {
-                while (messages.size() > 8) {
+                while (messages.size() > 398) {
                     messages.poll();
                 }
                 messages.add(new StatusMessage(message));

--- a/app/src/main/java/info/nightscout/android/medtronic/MainActivity.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/MainActivity.java
@@ -104,6 +104,14 @@ public class MainActivity extends AppCompatActivity implements OnSharedPreferenc
     public static short pumpBattery = 0;
     public static int countUnavailableSGV = 0;
 
+    // temporary debug stats for CNL connections
+    public static int dbgCNL_enterControlMode = 0;
+    public static int dbgCNL_enterPassthroughMode = 0;
+    public static int dbgCNL_openConnection = 0;
+    public static int dbgCNL_beginEHSMSession = 0;
+    public static int dbgCNL_clearMessage = 0;
+    public static int dbgCNL_not0x81 = 0;
+
     boolean mEnableCgmService = true;
     SharedPreferences prefs = null;
     private PumpInfo mActivePump;

--- a/app/src/main/java/info/nightscout/android/medtronic/MainActivity.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/MainActivity.java
@@ -94,8 +94,8 @@ public class MainActivity extends AppCompatActivity implements OnSharedPreferenc
     private int chartZoom = 3;
     private boolean hasZoomedChart = false;
 
-    private NumberFormat sgvFormatter;
-    private boolean mmolxl;
+    public static NumberFormat sgvFormatter;
+    public static boolean mmolxl;
     private boolean mmolxlDecimals;
 
     boolean mEnableCgmService = true;

--- a/app/src/main/java/info/nightscout/android/medtronic/MainActivity.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/MainActivity.java
@@ -114,19 +114,6 @@ public class MainActivity extends AppCompatActivity implements OnSharedPreferenc
     private StatusMessageReceiver statusMessageReceiver = new StatusMessageReceiver();
     private MedtronicCnlAlarmReceiver medtronicCnlAlarmReceiver = new MedtronicCnlAlarmReceiver();
 
-    public static String strFormatSGV(float sgvValue) {
-        if (mmolxl) {
-            NumberFormat sgvFormatter;
-            if (mmolxlDecimals)
-                sgvFormatter = new DecimalFormat("0.00");
-            else
-                sgvFormatter = new DecimalFormat("0.0");
-            return sgvFormatter.format(sgvValue / MMOLXLFACTOR);
-        } else {
-            return String.valueOf(sgvValue);
-        }
-    }
-
     public static long getNextPoll(PumpStatusEvent pumpStatusData) {
         long nextPoll = pumpStatusData.getEventDate().getTime() + pumpStatusData.getPumpTimeOffset()
                 + MedtronicCnlIntentService.POLL_GRACE_PERIOD_MS;
@@ -141,6 +128,20 @@ public class MainActivity extends AppCompatActivity implements OnSharedPreferenc
         }
 
         return nextPoll;
+    }
+
+    public static String strFormatSGV(float sgvValue) {
+        if (mmolxl) {
+            NumberFormat sgvFormatter;
+            if (mmolxlDecimals) {
+                sgvFormatter = new DecimalFormat("0.00");
+            } else {
+                sgvFormatter = new DecimalFormat("0.0");
+            }
+            return sgvFormatter.format(sgvValue / MMOLXLFACTOR);
+        } else {
+            return String.valueOf(sgvValue);
+        }
     }
 
     @Override

--- a/app/src/main/java/info/nightscout/android/medtronic/MainActivity.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/MainActivity.java
@@ -618,7 +618,10 @@ public class MainActivity extends AppCompatActivity implements OnSharedPreferenc
                         }
 
                         // TODO - handle isOffline in NightscoutUploadIntentService?
-                        uploadCgmData();
+
+ // >>>>> check this out as it's uploading before cnl comms finishes and may cause occasional channel changes due to wifi noise - cnl intent handles ns upload trigger after all comms finish
+ //                       uploadCgmData();
+
                         refreshDisplay();
                     }
                 });

--- a/app/src/main/java/info/nightscout/android/medtronic/MainActivity.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/MainActivity.java
@@ -58,6 +58,7 @@ import com.mikepenz.materialdrawer.model.interfaces.IDrawerItem;
 import java.text.DateFormat;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 import java.util.Queue;
@@ -318,17 +319,19 @@ public class MainActivity extends AppCompatActivity implements OnSharedPreferenc
         mChart.getGridLabelRenderer().setHumanRounding(false);
 
         mChart.getGridLabelRenderer().setLabelFormatter(new DefaultLabelFormatter() {
-            DateFormat mFormat = DateFormat.getTimeInstance(DateFormat.SHORT);
+//            DateFormat mFormat = DateFormat.getTimeInstance(DateFormat.SHORT);
+            DateFormat mFormat = new SimpleDateFormat("HH:mm");  // 24 hour format forced to fix label overlap
+
             @Override
             public String formatLabel(double value, boolean isValueX) {
                 if (isValueX) {
                     return mFormat.format(new Date((long) value));
                 } else {
-                    if (mmolxl) {
-                        return sgvFormatter.format(value / MMOLXLFACTOR);
-                    } else {
+//                    if (mmolxl) {
+//                        return sgvFormatter.format(value / MMOLXLFACTOR);
+//                    } else {
                         return sgvFormatter.format(value);
-                    }
+//                    }
                 }
             }}
         );
@@ -777,6 +780,9 @@ public class MainActivity extends AppCompatActivity implements OnSharedPreferenc
         }
 
         private void updateChart(RealmResults<PumpStatusEvent> results) {
+
+            mChart.getGridLabelRenderer().setNumHorizontalLabels(6);
+
             int size = results.size();
             if (size == 0) {
                 final long now = System.currentTimeMillis(),
@@ -807,9 +813,9 @@ public class MainActivity extends AppCompatActivity implements OnSharedPreferenc
                 int sgv = pumpStatus.getSgv();
 
                 if (mmolxl) {
-                    entries[pos++] = new DataPoint(pumpStatus.getEventDate(), pumpStatus.getSgv() / MMOLXLFACTOR);
+                    entries[pos++] = new DataPoint(pumpStatus.getEventDate(), (float) pumpStatus.getSgv() / MMOLXLFACTOR);
                 } else {
-                    entries[pos++] = new DataPoint(pumpStatus.getEventDate(), pumpStatus.getSgv());
+                    entries[pos++] = new DataPoint(pumpStatus.getEventDate(), (float) pumpStatus.getSgv());
                 }
             }
 
@@ -835,11 +841,11 @@ public class MainActivity extends AppCompatActivity implements OnSharedPreferenc
                         double sgv = dataPoint.getY();
 
                         StringBuilder sb = new StringBuilder(mFormat.format(new Date((long) dataPoint.getX())) + ": ");
-                        if (mmolxl) {
-                            sb.append(sgvFormatter.format(sgv / MMOLXLFACTOR));
-                        } else {
+//                        if (mmolxl) {
+//                            sb.append(sgvFormatter.format(sgv / MMOLXLFACTOR));
+//                        } else {
                             sb.append(sgvFormatter.format(sgv));
-                        }
+//                        }
                         Toast.makeText(getBaseContext(), sb.toString(), Toast.LENGTH_SHORT).show();
                     }
                 });
@@ -848,11 +854,11 @@ public class MainActivity extends AppCompatActivity implements OnSharedPreferenc
                     @Override
                     public void draw(Canvas canvas, Paint paint, float x, float y, DataPointInterface dataPoint) {
                         double sgv = dataPoint.getY();
-                        if (sgv < 80)
+                        if (sgv < (mmolxl?4.5:80))
                             paint.setColor(Color.RED);
-                        else if (sgv <= 180)
+                        else if (sgv <= (mmolxl?10:180))
                             paint.setColor(Color.GREEN);
-                        else if (sgv <= 260)
+                        else if (sgv <= (mmolxl?14:260))
                             paint.setColor(Color.YELLOW);
                         else
                             paint.setColor(Color.RED);

--- a/app/src/main/java/info/nightscout/android/medtronic/MedtronicCnlReader.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/MedtronicCnlReader.java
@@ -51,6 +51,8 @@ public class MedtronicCnlReader {
     private MedtronicCnlSession mPumpSession = new MedtronicCnlSession();
     private String mStickSerial = null;
 
+    private static final int TIMEOUT_MS = 0; //500  note: using a read "pause" has no effect on outcome and likely redundant due to clearMessage intercepting unread messages
+
     public MedtronicCnlReader(UsbHidDriver device) {
         mDevice = device;
     }
@@ -78,9 +80,9 @@ public class MedtronicCnlReader {
             doRetry = false;
             try {
                 new ContourNextLinkCommandMessage(ContourNextLinkCommandMessage.ASCII.NAK)
-                        .send(mDevice, 500).checkControlMessage(ContourNextLinkCommandMessage.ASCII.EOT);
+                        .send(mDevice, TIMEOUT_MS).checkControlMessage(ContourNextLinkCommandMessage.ASCII.EOT);
                 new ContourNextLinkCommandMessage(ContourNextLinkCommandMessage.ASCII.ENQ)
-                        .send(mDevice, 500).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ACK);
+                        .send(mDevice, TIMEOUT_MS).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ACK);
             } catch (UnexpectedMessageException e2) {
                 try {
                     new ContourNextLinkCommandMessage(ContourNextLinkCommandMessage.ASCII.EOT).send(mDevice);
@@ -95,11 +97,11 @@ public class MedtronicCnlReader {
     public void enterPassthroughMode() throws IOException, TimeoutException, UnexpectedMessageException, ChecksumException, EncryptionException {
         Log.d(TAG, "Begin enterPasshtroughMode");
         new ContourNextLinkCommandMessage("W|")
-                .send(mDevice, 500).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ACK);
+                .send(mDevice, TIMEOUT_MS).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ACK);
         new ContourNextLinkCommandMessage("Q|")
-                .send(mDevice, 500).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ACK);
+                .send(mDevice, TIMEOUT_MS).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ACK);
         new ContourNextLinkCommandMessage("1|")
-                .send(mDevice, 500).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ACK);
+                .send(mDevice, TIMEOUT_MS).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ACK);
         Log.d(TAG, "Finished enterPasshtroughMode");
     }
 
@@ -224,18 +226,18 @@ public class MedtronicCnlReader {
     public void endPassthroughMode() throws IOException, TimeoutException, UnexpectedMessageException, ChecksumException, EncryptionException {
         Log.d(TAG, "Begin endPassthroughMode");
         new ContourNextLinkCommandMessage("W|")
-                .send(mDevice, 500).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ACK);
+                .send(mDevice, TIMEOUT_MS).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ACK);
         new ContourNextLinkCommandMessage("Q|")
-                .send(mDevice, 500).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ACK);
+                .send(mDevice, TIMEOUT_MS).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ACK);
         new ContourNextLinkCommandMessage("0|")
-                .send(mDevice, 500).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ACK);
+                .send(mDevice, TIMEOUT_MS).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ACK);
         Log.d(TAG, "Finished endPassthroughMode");
     }
 
     public void endControlMode() throws IOException, TimeoutException, UnexpectedMessageException, ChecksumException, EncryptionException {
         Log.d(TAG, "Begin endControlMode");
         new ContourNextLinkCommandMessage(ContourNextLinkCommandMessage.ASCII.EOT)
-                .send(mDevice, 500).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ENQ);
+                .send(mDevice, TIMEOUT_MS).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ENQ);
         Log.d(TAG, "Finished endControlMode");
     }
 }

--- a/app/src/main/java/info/nightscout/android/medtronic/MedtronicCnlReader.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/MedtronicCnlReader.java
@@ -171,7 +171,17 @@ public class MedtronicCnlReader {
 
     public Date getPumpTime() throws EncryptionException, IOException, ChecksumException, TimeoutException, UnexpectedMessageException {
         Log.d(TAG, "Begin getPumpTime");
-        // FIXME - throw if not in EHSM mode (add a state machine)
+
+        // CNL<-->PUMP comms can have occasional short lived noise causing errors, retrying once catches this
+        try {
+            PumpTimeResponseMessage response = new PumpTimeRequestMessage(mPumpSession).send(mDevice);
+            Log.d(TAG, "Finished getPumpTime with date " + response.getPumpTime());
+            return response.getPumpTime();
+        } catch (UnexpectedMessageException e) {
+            Log.e(TAG, "Unexpected Message", e);
+        } catch (TimeoutException e) {
+            Log.e(TAG, "Timeout communicating with the Contour Next Link.", e);
+        }
 
         PumpTimeResponseMessage response = new PumpTimeRequestMessage(mPumpSession).send(mDevice);
 
@@ -182,7 +192,18 @@ public class MedtronicCnlReader {
     public PumpStatusEvent updatePumpStatus(PumpStatusEvent pumpRecord) throws IOException, EncryptionException, ChecksumException, TimeoutException, UnexpectedMessageException {
         Log.d(TAG, "Begin updatePumpStatus");
 
-        // FIXME - throw if not in EHSM mode (add a state machine)
+        // CNL<-->PUMP comms can have occasional short lived noise causing errors, retrying once catches this
+        try {
+            PumpStatusResponseMessage response = new PumpStatusRequestMessage(mPumpSession).send(mDevice);
+            response.updatePumpRecord(pumpRecord);
+            Log.d(TAG, "Finished updatePumpStatus");
+            return pumpRecord;
+        } catch (UnexpectedMessageException e) {
+            Log.e(TAG, "Unexpected Message", e);
+        } catch (TimeoutException e) {
+            Log.e(TAG, "Timeout communicating with the Contour Next Link.", e);
+        }
+
         PumpStatusResponseMessage response = new PumpStatusRequestMessage(mPumpSession).send(mDevice);
         response.updatePumpRecord(pumpRecord);
 

--- a/app/src/main/java/info/nightscout/android/medtronic/MedtronicCnlReader.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/MedtronicCnlReader.java
@@ -9,7 +9,6 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.Locale;
 import java.util.concurrent.TimeoutException;
 
 import info.nightscout.android.USB.UsbHidDriver;
@@ -51,7 +50,7 @@ public class MedtronicCnlReader {
     private MedtronicCnlSession mPumpSession = new MedtronicCnlSession();
     private String mStickSerial = null;
 
-    private static final int TIMEOUT_MS = 0; //500  note: using a read "pause" has no effect on outcome and likely redundant due to clearMessage intercepting unread messages
+    private static final int SLEEP_MS = 500;
 
     public MedtronicCnlReader(UsbHidDriver device) {
         mDevice = device;
@@ -80,9 +79,9 @@ public class MedtronicCnlReader {
             doRetry = false;
             try {
                 new ContourNextLinkCommandMessage(ContourNextLinkCommandMessage.ASCII.NAK)
-                        .send(mDevice, TIMEOUT_MS).checkControlMessage(ContourNextLinkCommandMessage.ASCII.EOT);
+                        .send(mDevice, SLEEP_MS).checkControlMessage(ContourNextLinkCommandMessage.ASCII.EOT);
                 new ContourNextLinkCommandMessage(ContourNextLinkCommandMessage.ASCII.ENQ)
-                        .send(mDevice, TIMEOUT_MS).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ACK);
+                        .send(mDevice, SLEEP_MS).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ACK);
             } catch (UnexpectedMessageException e2) {
                 try {
                     new ContourNextLinkCommandMessage(ContourNextLinkCommandMessage.ASCII.EOT).send(mDevice);
@@ -97,11 +96,11 @@ public class MedtronicCnlReader {
     public void enterPassthroughMode() throws IOException, TimeoutException, UnexpectedMessageException, ChecksumException, EncryptionException {
         Log.d(TAG, "Begin enterPasshtroughMode");
         new ContourNextLinkCommandMessage("W|")
-                .send(mDevice, TIMEOUT_MS).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ACK);
+                .send(mDevice, SLEEP_MS).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ACK);
         new ContourNextLinkCommandMessage("Q|")
-                .send(mDevice, TIMEOUT_MS).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ACK);
+                .send(mDevice, SLEEP_MS).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ACK);
         new ContourNextLinkCommandMessage("1|")
-                .send(mDevice, TIMEOUT_MS).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ACK);
+                .send(mDevice, SLEEP_MS).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ACK);
         Log.d(TAG, "Finished enterPasshtroughMode");
     }
 
@@ -226,18 +225,18 @@ public class MedtronicCnlReader {
     public void endPassthroughMode() throws IOException, TimeoutException, UnexpectedMessageException, ChecksumException, EncryptionException {
         Log.d(TAG, "Begin endPassthroughMode");
         new ContourNextLinkCommandMessage("W|")
-                .send(mDevice, TIMEOUT_MS).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ACK);
+                .send(mDevice, SLEEP_MS).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ACK);
         new ContourNextLinkCommandMessage("Q|")
-                .send(mDevice, TIMEOUT_MS).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ACK);
+                .send(mDevice, SLEEP_MS).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ACK);
         new ContourNextLinkCommandMessage("0|")
-                .send(mDevice, TIMEOUT_MS).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ACK);
+                .send(mDevice, SLEEP_MS).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ACK);
         Log.d(TAG, "Finished endPassthroughMode");
     }
 
     public void endControlMode() throws IOException, TimeoutException, UnexpectedMessageException, ChecksumException, EncryptionException {
         Log.d(TAG, "Begin endControlMode");
         new ContourNextLinkCommandMessage(ContourNextLinkCommandMessage.ASCII.EOT)
-                .send(mDevice, TIMEOUT_MS).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ENQ);
+                .send(mDevice, SLEEP_MS).checkControlMessage(ContourNextLinkCommandMessage.ASCII.ENQ);
         Log.d(TAG, "Finished endControlMode");
     }
 }

--- a/app/src/main/java/info/nightscout/android/medtronic/MedtronicCnlReader.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/MedtronicCnlReader.java
@@ -150,9 +150,11 @@ public class MedtronicCnlReader {
             ChannelNegotiateResponseMessage response = new ChannelNegotiateRequestMessage(mPumpSession).send(mDevice);
 
             if (response.getRadioChannel() == mPumpSession.getRadioChannel()) {
+                mPumpSession.setRadioRSSI(response.getRadioRSSI());
                 break;
             } else {
                 mPumpSession.setRadioChannel((byte)0);
+                mPumpSession.setRadioRSSI((byte)0);
             }
         }
 

--- a/app/src/main/java/info/nightscout/android/medtronic/MedtronicCnlSession.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/MedtronicCnlSession.java
@@ -20,6 +20,8 @@ public class MedtronicCnlSession {
     private long pumpMAC;
 
     private byte radioChannel;
+    private byte radioRSSI;
+
     private int bayerSequenceNumber = 1;
     private int medtronicSequenceNumber = 1;
 
@@ -80,6 +82,14 @@ public class MedtronicCnlSession {
         return radioChannel;
     }
 
+    public byte getRadioRSSI() {
+        return radioRSSI;
+    }
+
+    public int getRadioRSSIpercentage() {
+        return (((int) radioRSSI & 0x00FF) * 100) / 0xA8;
+    }
+
     public void incrBayerSequenceNumber() {
         bayerSequenceNumber++;
     }
@@ -90,6 +100,10 @@ public class MedtronicCnlSession {
 
     public void setRadioChannel(byte radioChannel) {
         this.radioChannel = radioChannel;
+    }
+
+    public void setRadioRSSI(byte radioRSSI) {
+        this.radioRSSI = radioRSSI;
     }
 
     public void setHMAC(byte[] hmac) {

--- a/app/src/main/java/info/nightscout/android/medtronic/message/ChannelNegotiateResponseMessage.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/message/ChannelNegotiateResponseMessage.java
@@ -16,6 +16,7 @@ public class ChannelNegotiateResponseMessage extends ContourNextLinkBinaryRespon
     private static final String TAG = ChannelNegotiateResponseMessage.class.getSimpleName();
 
     private byte radioChannel = 0;
+    private byte radioRSSI = 0;
 
     protected ChannelNegotiateResponseMessage(MedtronicCnlSession pumpSession, byte[] payload) throws EncryptionException, ChecksumException, IOException {
         super(payload);
@@ -25,15 +26,21 @@ public class ChannelNegotiateResponseMessage extends ContourNextLinkBinaryRespon
         Log.d(TAG, "negotiateChannel: Check response length");
         if (responseBytes.length > 46) {
             radioChannel = responseBytes[76];
+            radioRSSI = responseBytes[59];
             if (responseBytes[76] != pumpSession.getRadioChannel()) {
                 throw new IOException(String.format(Locale.getDefault(), "Expected to get a message for channel %d. Got %d", pumpSession.getRadioChannel(), responseBytes[76]));
             }
         } else {
             radioChannel = ((byte) 0);
+            radioRSSI = ((byte) 0);
         }
     }
 
     public byte getRadioChannel() {
         return radioChannel;
+    }
+
+    public byte getRadioRSSI() {
+        return radioRSSI;
     }
 }

--- a/app/src/main/java/info/nightscout/android/medtronic/message/ContourNextLinkMessage.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/message/ContourNextLinkMessage.java
@@ -152,7 +152,6 @@ public abstract class ContourNextLinkMessage {
             if (responseBytes[18] != (byte) 0x81) {
                 doRetry = true;
                 Log.d(TAG, "readMessage0x81: did not get 0x81 response, got " + responseBytes[18]);
-                MainActivity.dbgCNL_not0x81++;
             } else {
                 doRetry = false;
                 responseSize = responseBytes.length;
@@ -185,7 +184,6 @@ public abstract class ContourNextLinkMessage {
 
         if (bytesClear > 0) {
             Log.d(TAG, "clearMessage: message stream cleared bytes: " + bytesClear);
-            MainActivity.dbgCNL_clearMessage++;
         }
 
         return bytesClear;

--- a/app/src/main/java/info/nightscout/android/medtronic/message/ContourNextLinkMessage.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/message/ContourNextLinkMessage.java
@@ -20,7 +20,7 @@ public abstract class ContourNextLinkMessage {
     private static final String TAG = ContourNextLinkMessage.class.getSimpleName();
 
     private static final int USB_BLOCKSIZE = 64;
-    private static final int READ_TIMEOUT_MS = 10000;
+    private static final int READ_TIMEOUT_MS = 15000; //ASTM standard is 15 seconds (note was previously set at 10 seconds)
     private static final String BAYER_USB_HEADER = "ABC";
 
     protected ByteBuffer mPayload;
@@ -141,6 +141,56 @@ public abstract class ContourNextLinkMessage {
 
         return responseMessage.toByteArray();
     }
+
+    // safety check to make sure a expected 0x81 response is received before next expected 0x80 response
+    // very infrequent as clearMessage catches most issues but very important to save a CNL error situation
+
+    protected int readMessage_0x81(UsbHidDriver mDevice) throws IOException, TimeoutException {
+
+        int responseSize = 0;
+        boolean doRetry;
+        do {
+            byte[] responseBytes = readMessage(mDevice);
+            if (responseBytes[18] != (byte) 0x81) {
+                doRetry = true;
+                Log.d(TAG, "readMessage0x81: did not get 0x81 response, got " + responseBytes[18]);
+            } else {
+                doRetry = false;
+                responseSize = responseBytes.length;
+            }
+
+        } while (doRetry);
+
+        return responseSize;
+    }
+
+    // intercept unexpected messages from the CNL
+    // these usually come from pump requests as it can occasionally resend message responses several times (possibly due to a missed CNL ACK during CNL-PUMP comms?)
+    // mostly noted on the higher radio channels, channel 26 shows this the most
+    // if these messages are not cleared the CNL will likely error needing to be unplugged to reset as it expects them to be read before any further commands are sent
+
+    protected int clearMessage(UsbHidDriver mDevice) throws IOException {
+
+        byte[] responseBuffer = new byte[USB_BLOCKSIZE];
+        int bytesRead;
+        int bytesClear = 0;
+
+        do {
+            bytesRead = mDevice.read(responseBuffer, 2000);
+            if (bytesRead > 0) {
+                bytesClear += bytesRead;
+                String responseString = HexDump.dumpHexString(responseBuffer);
+                Log.d(TAG, "READ: " + responseString);
+            }
+        } while (bytesRead > 0);
+
+        if (bytesClear > 0) {
+            Log.d(TAG, "clearMessage: message stream cleared bytes: " + bytesClear);
+        }
+
+        return bytesClear;
+    }
+
 
     public enum ASCII {
         STX(0x02),

--- a/app/src/main/java/info/nightscout/android/medtronic/message/ContourNextLinkMessage.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/message/ContourNextLinkMessage.java
@@ -8,9 +8,7 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.TimeoutException;
 
 import info.nightscout.android.USB.UsbHidDriver;
-import info.nightscout.android.medtronic.exception.ChecksumException;
-import info.nightscout.android.medtronic.exception.EncryptionException;
-import info.nightscout.android.medtronic.exception.UnexpectedMessageException;
+import info.nightscout.android.medtronic.MainActivity;
 import info.nightscout.android.utils.HexDump;
 
 /**
@@ -154,6 +152,7 @@ public abstract class ContourNextLinkMessage {
             if (responseBytes[18] != (byte) 0x81) {
                 doRetry = true;
                 Log.d(TAG, "readMessage0x81: did not get 0x81 response, got " + responseBytes[18]);
+                MainActivity.dbgCNL_not0x81++;
             } else {
                 doRetry = false;
                 responseSize = responseBytes.length;
@@ -186,6 +185,7 @@ public abstract class ContourNextLinkMessage {
 
         if (bytesClear > 0) {
             Log.d(TAG, "clearMessage: message stream cleared bytes: " + bytesClear);
+            MainActivity.dbgCNL_clearMessage++;
         }
 
         return bytesClear;

--- a/app/src/main/java/info/nightscout/android/medtronic/message/EHSMMessage.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/message/EHSMMessage.java
@@ -20,6 +20,10 @@ public class EHSMMessage extends  MedtronicSendMessageRequestMessage<ContourNext
 
     @Override
     public ContourNextLinkResponseMessage send(UsbHidDriver mDevice, int millis) throws IOException, TimeoutException, UnexpectedMessageException {
+
+        // clear unexpected incoming messages
+        clearMessage(mDevice);
+
         sendMessage(mDevice);
         if (millis > 0) {
             try {
@@ -27,11 +31,17 @@ public class EHSMMessage extends  MedtronicSendMessageRequestMessage<ContourNext
             } catch (InterruptedException e) {
             }
         }
+
         // The End EHSM Session only has an 0x81 response
+        if (readMessage_0x81(mDevice) != 48) {
+            throw new UnexpectedMessageException("length of EHSMMessage response does not match");
+        }
+/*
         readMessage(mDevice);
         if (this.encode().length != 54) {
             throw new UnexpectedMessageException("length of EHSMMessage response does not match");
         }
+*/
         return null;
     }
 }

--- a/app/src/main/java/info/nightscout/android/medtronic/message/PumpStatusRequestMessage.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/message/PumpStatusRequestMessage.java
@@ -22,6 +22,10 @@ public class PumpStatusRequestMessage extends MedtronicSendMessageRequestMessage
     }
 
     public PumpStatusResponseMessage send(UsbHidDriver mDevice, int millis) throws IOException, TimeoutException, ChecksumException, EncryptionException, UnexpectedMessageException {
+
+        // clear unexpected incoming messages
+        clearMessage(mDevice);
+
         sendMessage(mDevice);
         if (millis > 0) {
             try {
@@ -31,7 +35,7 @@ public class PumpStatusRequestMessage extends MedtronicSendMessageRequestMessage
             }
         }
         // Read the 0x81
-        readMessage(mDevice);
+        readMessage_0x81(mDevice);
         if (millis > 0) {
             try {
                 Log.d(TAG, "waiting " + millis +" ms");

--- a/app/src/main/java/info/nightscout/android/medtronic/message/PumpStatusRequestMessage.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/message/PumpStatusRequestMessage.java
@@ -23,9 +23,6 @@ public class PumpStatusRequestMessage extends MedtronicSendMessageRequestMessage
 
     public PumpStatusResponseMessage send(UsbHidDriver mDevice, int millis) throws IOException, TimeoutException, ChecksumException, EncryptionException, UnexpectedMessageException {
 
-        // clear unexpected incoming messages
-        clearMessage(mDevice);
-
         sendMessage(mDevice);
         if (millis > 0) {
             try {
@@ -44,6 +41,9 @@ public class PumpStatusRequestMessage extends MedtronicSendMessageRequestMessage
             }
         }
         PumpStatusResponseMessage response = this.getResponse(readMessage(mDevice));
+
+        // clear unexpected incoming messages
+        clearMessage(mDevice);
 
         return response;
     }

--- a/app/src/main/java/info/nightscout/android/medtronic/message/PumpTimeRequestMessage.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/message/PumpTimeRequestMessage.java
@@ -20,9 +20,6 @@ public class PumpTimeRequestMessage extends MedtronicSendMessageRequestMessage<P
     @Override
     public PumpTimeResponseMessage send(UsbHidDriver mDevice, int millis) throws IOException, TimeoutException, ChecksumException, EncryptionException, UnexpectedMessageException {
 
-        // clear unexpected incoming messages
-        clearMessage(mDevice);
-
         sendMessage(mDevice);
         if (millis > 0) {
             try {
@@ -40,6 +37,9 @@ public class PumpTimeRequestMessage extends MedtronicSendMessageRequestMessage<P
         }
         // Read the 0x80
         PumpTimeResponseMessage response = this.getResponse(readMessage(mDevice));
+
+        // Pump sends additional 0x80 message when not using EHSM, lets clear this and any unexpected incoming messages
+        clearMessage(mDevice);
 
         return response;
     }

--- a/app/src/main/java/info/nightscout/android/medtronic/message/PumpTimeRequestMessage.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/message/PumpTimeRequestMessage.java
@@ -19,6 +19,10 @@ public class PumpTimeRequestMessage extends MedtronicSendMessageRequestMessage<P
 
     @Override
     public PumpTimeResponseMessage send(UsbHidDriver mDevice, int millis) throws IOException, TimeoutException, ChecksumException, EncryptionException, UnexpectedMessageException {
+
+        // clear unexpected incoming messages
+        clearMessage(mDevice);
+
         sendMessage(mDevice);
         if (millis > 0) {
             try {
@@ -27,7 +31,7 @@ public class PumpTimeRequestMessage extends MedtronicSendMessageRequestMessage<P
             }
         }
         // Read the 0x81
-        readMessage(mDevice);
+        readMessage_0x81(mDevice);
         if (millis > 0) {
             try {
                 Thread.sleep(millis);

--- a/app/src/main/java/info/nightscout/android/medtronic/message/PumpTimeResponseMessage.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/message/PumpTimeResponseMessage.java
@@ -29,7 +29,6 @@ public class PumpTimeResponseMessage extends MedtronicSendMessageResponseMessage
             // TODO - deal with this more elegantly
             Log.e(TAG, "Invalid message received for getPumpTime");
             throw new UnexpectedMessageException("Invalid message received for getPumpTime");
-//            pumpTime = new Date();
         } else {
             ByteBuffer dateBuffer = ByteBuffer.allocate(8);
             dateBuffer.order(ByteOrder.BIG_ENDIAN);

--- a/app/src/main/java/info/nightscout/android/medtronic/message/PumpTimeResponseMessage.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/message/PumpTimeResponseMessage.java
@@ -10,6 +10,7 @@ import info.nightscout.android.BuildConfig;
 import info.nightscout.android.medtronic.MedtronicCnlSession;
 import info.nightscout.android.medtronic.exception.ChecksumException;
 import info.nightscout.android.medtronic.exception.EncryptionException;
+import info.nightscout.android.medtronic.exception.UnexpectedMessageException;
 import info.nightscout.android.utils.HexDump;
 
 /**
@@ -20,14 +21,15 @@ public class PumpTimeResponseMessage extends MedtronicSendMessageResponseMessage
 
     private Date pumpTime;
 
-    protected PumpTimeResponseMessage(MedtronicCnlSession pumpSession, byte[] payload) throws EncryptionException, ChecksumException {
+    protected PumpTimeResponseMessage(MedtronicCnlSession pumpSession, byte[] payload) throws EncryptionException, ChecksumException, UnexpectedMessageException {
         super(pumpSession, payload);
 
         if (this.encode().length < (61 + 8)) {
             // Invalid message. Return an invalid date.
             // TODO - deal with this more elegantly
             Log.e(TAG, "Invalid message received for getPumpTime");
-            pumpTime = new Date();
+            throw new UnexpectedMessageException("Invalid message received for getPumpTime");
+//            pumpTime = new Date();
         } else {
             ByteBuffer dateBuffer = ByteBuffer.allocate(8);
             dateBuffer.order(ByteOrder.BIG_ENDIAN);

--- a/app/src/main/java/info/nightscout/android/medtronic/service/MedtronicCnlAlarmManager.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/service/MedtronicCnlAlarmManager.java
@@ -80,7 +80,8 @@ public class MedtronicCnlAlarmManager {
 
     // restarting the alarm after MedtronicCnlIntentService.POLL_PERIOD_MS from now
     public static void restartAlarm() {
-        setAlarmAfterMillis(MainActivity.pollInterval + MedtronicCnlIntentService.POLL_GRACE_PERIOD_MS);
+        //setAlarmAfterMillis(MainActivity.pollInterval + MedtronicCnlIntentService.POLL_GRACE_PERIOD_MS);
+        setAlarmAfterMillis(MainActivity.pollInterval); // grace already accounted for when using current intent time to set default restart
     }
 
     // Cancel the alarm.

--- a/app/src/main/java/info/nightscout/android/medtronic/service/MedtronicCnlIntentService.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/service/MedtronicCnlIntentService.java
@@ -200,7 +200,7 @@ public class MedtronicCnlIntentService extends IntentService {
 
                     // reduce polling interval to half until pump is available
                     //TODO: make it configurable???
-                    MedtronicCnlAlarmManager.setAlarm(System.currentTimeMillis() + MainActivity.pollInterval/2L);
+                    MedtronicCnlAlarmManager.setAlarm(System.currentTimeMillis() + (MainActivity.pollInterval  + MedtronicCnlIntentService.POLL_GRACE_PERIOD_MS)/2L);
                 } else {
                     activePump.setLastRadioChannel(radioChannel);
                     sendStatus(String.format(Locale.getDefault(), "Connected to Contour Next Link on channel %d.", (int) radioChannel));

--- a/app/src/main/java/info/nightscout/android/medtronic/service/MedtronicCnlIntentService.java
+++ b/app/src/main/java/info/nightscout/android/medtronic/service/MedtronicCnlIntentService.java
@@ -213,7 +213,8 @@ public class MedtronicCnlIntentService extends IntentService {
                 } else {
                     setActivePumpMac(pumpMAC);
                     activePump.setLastRadioChannel(radioChannel);
-                    sendStatus(String.format(Locale.getDefault(), "Connected to Contour Next Link on channel %d.", (int) radioChannel));
+                    //sendStatus(String.format(Locale.getDefault(), "Connected to Contour Next Link on channel %d.", (int) radioChannel));
+                    sendStatus(String.format(Locale.getDefault(), "Connected on channel %d  RSSI: %d%%", (int) radioChannel, cnlReader.getPumpSession().getRadioRSSIpercentage()));
                     Log.d(TAG, String.format("Connected to Contour Next Link on channel %d.", (int) radioChannel));
                     cnlReader.beginEHSMSession();
 

--- a/app/src/main/java/info/nightscout/android/xdrip_plus/XDripPlusUploadIntentService.java
+++ b/app/src/main/java/info/nightscout/android/xdrip_plus/XDripPlusUploadIntentService.java
@@ -70,6 +70,7 @@ public class XDripPlusUploadIntentService extends IntentService {
             List<PumpStatusEvent> records = all_records.subList(0, 1);
             doXDripUpload(records);
         }
+        mRealm.close();
         XDripPlusUploadReceiver.completeWakefulIntent(intent);
     }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -128,18 +128,21 @@
         android:id="@+id/scrollView"
         android:layout_width="match_parent"
         android:layout_height="fill_parent">
+        android:gravity="bottom"
 
         <LinearLayout
             android:orientation="vertical"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
+            android:gravity="bottom"
 
             <TextView
                 android:id="@+id/textview_log"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
                 android:layout_margin="10sp"
-                android:maxLines="20"
+                android:maxLines="800"
+                android:gravity="bottom"
                 android:text="" />
         </LinearLayout>
     </ScrollView>


### PR DESCRIPTION
Based on the develop branch this is my take on making the uploader unbreakable and I've been using it 24/7 now without a hitch.

This handles radio channel changes and cnl error issues and for me has reduced the "---" on the pump from over 20 times per 24 hours to 1 or 2 times per 24 hours. Pump will also now always recover within 1 period where before at it's worse it could 1/2 hour or so!

There is a smart polling system that adds anti pump-sensor poll clash detection - always on time at the right time (that's how I roll brother). 

Seemingly random CNL errors needing a unplug to reset would happen every day or 2 in a 24/7 setup sometimes even more frequently - these have been completely stopping for me now.

There are a number of other fixes and changes in here too and a nice little surprise!!! Ah heck I'm no good with surprises - I found a RSSI signal indicator so you can now see your reception quality between cnl and pump.
     